### PR TITLE
Fix announcement class not being set properly in Scenario

### DIFF
--- a/lib_bgp_simulator/simulation_framework/scenarios/scenario.py
+++ b/lib_bgp_simulator/simulation_framework/scenarios/scenario.py
@@ -47,7 +47,7 @@ class Scenario(ABC):
         since that is the default
         """
 
-        self.AnnCls = Announcement
+        self.AnnCls = AnnCls
         self.BaseASCls = BaseASCls
         self.AdoptASCls = AdoptASCls
 


### PR DESCRIPTION
This likely wasn't noticed before because all the simulations at that point used regular Announcements.