### PR TITLE
Remove parse_cpus default override in __main__.py

### DIFF
--- a/bgpy/__main__.py
+++ b/bgpy/__main__.py
@@ -24,7 +24,8 @@ def main():
             ScenarioConfig(ScenarioCls=SubprefixHijack, AdoptPolicyCls=ROV),
         ),
         output_dir=Path("~/Desktop/main_ex").expanduser(),
-        num_trials=10
+        num_trials=10,
+        cpu_count=1
     )
     sim.run()
 

--- a/bgpy/__main__.py
+++ b/bgpy/__main__.py
@@ -26,7 +26,9 @@ def main():
         ),
         output_dir=Path("~/Desktop/main_ex").expanduser(),
         num_trials=10,
-        cpu_count=min(cpu_count()-1, 1) # Suggested value. Note that this is also the default
+        cpu_count=min(
+            cpu_count() - 1, 1
+        ),  # Suggested value. Note that this is also the default
     )
     sim.run()
 

--- a/bgpy/__main__.py
+++ b/bgpy/__main__.py
@@ -1,3 +1,4 @@
+from multiprocessing import cpu_count
 from pathlib import Path
 
 from bgpy.shared.enums import SpecialPercentAdoptions
@@ -25,7 +26,7 @@ def main():
         ),
         output_dir=Path("~/Desktop/main_ex").expanduser(),
         num_trials=10,
-        cpu_count=1
+        cpu_count=min(cpu_count()-1, 1) # Suggested value. Note that this is also the default
     )
     sim.run()
 

--- a/bgpy/__main__.py
+++ b/bgpy/__main__.py
@@ -24,8 +24,7 @@ def main():
             ScenarioConfig(ScenarioCls=SubprefixHijack, AdoptPolicyCls=ROV),
         ),
         output_dir=Path("~/Desktop/main_ex").expanduser(),
-        num_trials=10,
-        parse_cpus=10,
+        num_trials=10
     )
     sim.run()
 


### PR DESCRIPTION
`parse_cpus` is an integer value, passed to a `Simulation` instance, which dictates the number of CPUs to be used. In general, it should not exceed the number of actual cores a machine has (for obvious reasons), and indeed the default value of `parse_cpus = max(cpu_count() - 1, 1)` does not do this. 

However, I found preset simulations which override this default and assume that the user has a 10-core CPU just lying around. In particular I noticed this in `bgpy/__main__.py` when I tried to run `python3 -m bgpy` to test the simulation and found that the simulator incorrectly thought I had 10 cores. I only removed this default for that file, but I also found it in the following simulations:

- `scripts/dependent_ex.py`
- `scripts/aspawn_debug.py`
- `scripts/tutorial/main_tutorial/simulation.py` (instead uses `parse_cpus = cpu_count()`, which does not leave an extra CPU core for the system)

It may be of interest to you to update these files accordingly as well. I can add another commit to change these, unless you don't plan on using these examples again.