### PR TITLE
Accidental route leak fix

### DIFF
--- a/bgpy/simulation_framework/scenarios/custom_scenarios/accidental_route_leak.py
+++ b/bgpy/simulation_framework/scenarios/custom_scenarios/accidental_route_leak.py
@@ -202,3 +202,12 @@ class AccidentalRouteLeak(VictimsPrefix):
         """
 
         return super()._untracked_asns | self._attackers_customer_cones_asns
+
+    @property
+    def untracked_asns(self) -> frozenset[int]:
+        """Returns ASNs that shouldn't be tracked by the metric tracker
+
+        By default just the default adopters and non adopters
+        """
+
+        return super().untracked_asns

--- a/bgpy/simulation_framework/scenarios/custom_scenarios/accidental_route_leak.py
+++ b/bgpy/simulation_framework/scenarios/custom_scenarios/accidental_route_leak.py
@@ -192,6 +192,18 @@ class AccidentalRouteLeak(VictimsPrefix):
             ]
         )
 
+
+    @property
+    def untracked_asns(self) -> frozenset[int]:
+        """Returns ASNs that shouldn't be tracked by the metric tracker
+
+        By default just the default adopters and non adopters
+        however for the route leak, we don't want to track the customers of the
+        leaker, since you can not "leak" to your own customers
+        """
+        return super().untracked_asns | self._attackers_customer_cones_asns
+    
+    
     @property
     def _untracked_asns(self) -> frozenset[int]:
         """Returns ASNs that shouldn't be tracked by the metric tracker
@@ -201,13 +213,13 @@ class AccidentalRouteLeak(VictimsPrefix):
         leaker, since you can not "leak" to your own customers
         """
 
-        return super()._untracked_asns | self._attackers_customer_cones_asns
+        warnings.warn(
+            "_untracked_asns is deprecated, please use untracked_asns instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.untracked_asns
 
-    @property
-    def untracked_asns(self) -> frozenset[int]:
-        """Returns ASNs that shouldn't be tracked by the metric tracker
+    
 
-        By default just the default adopters and non adopters
-        """
-
-        return super().untracked_asns
+        

--- a/bgpy/simulation_framework/scenarios/custom_scenarios/accidental_route_leak.py
+++ b/bgpy/simulation_framework/scenarios/custom_scenarios/accidental_route_leak.py
@@ -218,7 +218,7 @@ class AccidentalRouteLeak(VictimsPrefix):
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.untracked_asns
+        return super().untracked_asns | self._attackers_customer_cones_asns
 
     
 


### PR DESCRIPTION
The untracked_asns property in AccidentalRouteLeak is not correctly inherited from the Scenario class in scenario.py. I am fixing this by inheriting the untracked_asns property as well as _untracked_asns property. This fixes the issue by catching calls to untracked_asns and calls to the property with a leading underscore (_untracked_asns).